### PR TITLE
Add nested objects support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,4 @@
 
 * [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
 * [ ] Have you written new tests for your core changes, as applicable?
-* [ ] Have you successfully ran tests with your changes locally?
+* [ ] Have you successfully run tests with your changes locally?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,6 @@
 * [ ] New feature (non-breaking change which adds functionality)
 * [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
-
 ### All Submissions:
 
 * [ ] Have you followed the guidelines in our Contributing document?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If you find a bug, have a feature request or even want to contribute an enhancem
 
 ## If you find what looks like a bug:
 
-  * Check the [issue tracker](/justeat/ts-jsonschema-builder/issues "Issues") to see if anyone else has reported the issue.
+  * Check the [issue tracker](https://github.com/justeat/ts-jsonschema-builder/issues) to see if anyone else has reported the issue.
   * Make sure you are using the latest version of builder
   * If you are still having an issue, create an issue including:
     * Information you will need to reproduce and diagnose the problem

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This builder takes advantage of TypeScript [Generics](https://www.typescriptlang
 
 Builder is packaged as ECMAScript 5. This means it can be used in vanilla JS projects, but you will not get a rich IntelliSense support.
 
-⚠ In beta, support is not complete. See below for what is supported.  
-V1 of the builder aims to implement Draft-V4
+⚠ Builder aims to implement Draft-V4
+See [wiki](https://github.com/justeat/ts-jsonschema-builder/wiki) for all supported features
 
 ![Builder demo](https://github.com/justeat/ts-jsonschema-builder/raw/master/assets/ts-schema-demo.gif)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ts-jsonschema-builder",
-  "version": "0.1.0",
+  "name": "@justeat/ts-jsonschema-builder",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,9 +25,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
-      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
+      "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
       "dev": true
     },
     "@types/esprima": {
@@ -47,7 +47,7 @@
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true,
       "optional": true
@@ -59,9 +59,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-      "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+      "version": "12.12.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.20.tgz",
+      "integrity": "sha512-VAe+DiwpnC/g448uN+/3gRl4th0BTdrR9gSLIOHA+SUQskaYZQDOHG7xmjiE7JUhjbXnbXytf6Ih+/pA6CtMFQ==",
+      "dev": true
     },
     "ajv": {
       "version": "6.10.2",
@@ -107,7 +108,7 @@
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
@@ -195,26 +196,48 @@
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -232,9 +255,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "concat-map": {
@@ -242,19 +265,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
-      "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
     },
     "debug": {
       "version": "3.2.6",
@@ -308,33 +318,29 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.17.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+      "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -359,30 +365,15 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
-    },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
@@ -424,18 +415,9 @@
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
-    },
-    "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      }
     },
     "glob": {
       "version": "7.1.3",
@@ -473,9 +455,9 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "he": {
@@ -500,16 +482,10 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-      "dev": true
-    },
     "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
       "dev": true
     },
     "is-callable": {
@@ -531,27 +507,21 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "isexe": {
@@ -594,20 +564,11 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://packages.je-labs.com/npm/private-npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true
         }
-      }
-    },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^2.0.0"
       }
     },
     "locate-path": {
@@ -641,32 +602,6 @@
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -678,13 +613,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -692,9 +627,9 @@
       }
     },
     "mocha": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
-      "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -717,21 +652,15 @@
         "supports-color": "6.0.0",
         "which": "1.3.1",
         "wide-align": "1.1.3",
-        "yargs": "13.2.2",
-        "yargs-parser": "13.0.0",
-        "yargs-unparser": "1.5.0"
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1",
+        "yargs-unparser": "1.6.0"
       }
     },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-environment-flags": {
@@ -744,19 +673,10 @@
         "semver": "^5.7.0"
       }
     },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
       "dev": true
     },
     "object-keys": {
@@ -778,13 +698,13 @@
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "once": {
@@ -796,39 +716,10 @@
         "wrappy": "1"
       }
     },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-      "dev": true
-    },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -861,12 +752,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
@@ -875,19 +760,9 @@
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -908,45 +783,24 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.0.tgz",
+      "integrity": "sha512-uviWSi5N67j3t3UKFxej1loCH0VZn5XuqdNxoLShPcYPw6cUZn74K1VRj+9myynRX03bxIBEkwlkob/ujLsJVw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "source-map": {
@@ -981,6 +835,26 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -992,16 +866,10 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true,
       "optional": true
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -1020,7 +888,7 @@
     },
     "ts-mocha": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-6.0.0.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/ts-mocha/-/ts-mocha-6.0.0.tgz",
       "integrity": "sha512-ZCtJK8WXxHNbFNjvUKQIXZby/+ybQQkaBcM/3QhBQUfwjpdGFE9F6iWsHhF5ifQNFV/lWiOODi2VMD5AyPcQyg==",
       "dev": true,
       "requires": {
@@ -1046,7 +914,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://packages.je-labs.com/npm/private-npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -1068,7 +936,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://packages.je-labs.com/npm/private-npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true
@@ -1082,16 +950,16 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
-      "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
-        "diff": "^3.2.0",
+        "diff": "^4.0.1",
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
@@ -1100,6 +968,14 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        }
       }
     },
     "tsutils": {
@@ -1118,9 +994,10 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
@@ -1156,48 +1033,40 @@
       }
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1215,22 +1084,21 @@
       "dev": true
     },
     "yargs": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
+        "cliui": "^5.0.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^2.0.1",
-        "os-locale": "^3.1.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.0.0"
+        "yargs-parser": "^13.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1262,9 +1130,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
@@ -1272,63 +1140,19 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
       "dev": true,
       "requires": {
         "flat": "^4.1.0",
-        "lodash": "^4.17.11",
-        "yargs": "^12.0.5"
-      },
-      "dependencies": {
-        "get-caller-file": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       }
     },
     "yn": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "resolved": "http://packages.je-labs.com/npm/private-npm/yn/-/yn-2.0.0.tgz",
       "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -18,18 +18,18 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/node": "^12.7.0",
-    "esprima": "^4.0.1",
-    "typescript": "^3.5.3"
+    "esprima": "^4.0.1"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.7",
+    "@types/node": "^12.12.20",
+    "typescript": "^3.7.3",
+    "@types/chai": "^4.2.7",
     "@types/esprima": "^4.0.2",
     "@types/mocha": "^5.2.7",
     "ajv": "^6.10.2",
     "chai": "^4.2.0",
-    "mocha": "^6.2.0",
+    "mocha": "^6.2.2",
     "ts-mocha": "^6.0.0",
-    "tslint": "^5.18.0"
+    "tslint": "^5.20.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/ts-jsonschema-builder",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Fluent TypeScript JSON Schema Builder with IntelliSense support.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema-parser.ts
+++ b/src/schema-parser.ts
@@ -1,5 +1,4 @@
-import { StringSchema, NumberSchema, BooleanSchema } from "./";
-import { PropertySchema } from "type-schema";
+import { StringSchema, NumberSchema, BooleanSchema, PropertySchema } from "./";
 
 export function parseSchema(value: any): PropertySchema {
   if (value instanceof RegExp) return new StringSchema({ type: "string", pattern: value });
@@ -16,6 +15,7 @@ export function parseSchema(value: any): PropertySchema {
   if (typeof value === "object" && value.constructor.name === "OneOf") return value;
   if (typeof value === "object" && value.constructor.name === "AllOf") return value;
   if (typeof value === "object" && value.constructor.name === "Not") return value;
+  if (typeof value === "object" && value.constructor.name === "Schema") return value;
 
   if (value instanceof Function) return new NumberSchema(value);
 

--- a/src/type-schema.ts
+++ b/src/type-schema.ts
@@ -8,7 +8,7 @@ export interface ITypeSchema<T> extends ISchema {
 
 export class PropertySchema implements ISchema {
   public isSchema = true;
-  required?: boolean = true;
+  public required?: boolean = true;
 
   constructor(schema: ISchema) {
     schema = schema || {};

--- a/src/type-schema.ts
+++ b/src/type-schema.ts
@@ -21,6 +21,7 @@ export class PropertySchema implements ISchema {
     return Object.assign({}, this);
   }
 }
+
 export class TypeSchema<T> extends PropertySchema implements ITypeSchema<T> {
   readonly type?: T;
 

--- a/tests/array.spec.ts
+++ b/tests/array.spec.ts
@@ -14,7 +14,7 @@ describe("Array", () => {
    */
   describe("Type", () => {
 
-    it("Should pass when property type matches ", () => {
+    it("Should pass when property type matches", () => {
 
       const model: Model = {
         ArrayProp: []

--- a/tests/boolean.spec.ts
+++ b/tests/boolean.spec.ts
@@ -9,7 +9,7 @@ describe("Exact Bool validation", () => {
    */
   describe("Type", () => {
 
-    it("Should pass when property type matches ", () => {
+    it("Should pass when property type matches", () => {
 
       const model: Model = {
         BooleanProp: true
@@ -60,7 +60,7 @@ describe("Exact Bool validation", () => {
     });
   });
 
-  it("Should pass when Bool matches exactly ", () => {
+  it("Should pass when Bool matches exactly", () => {
 
     const model: Model = {
       BooleanProp: false
@@ -73,7 +73,7 @@ describe("Exact Bool validation", () => {
     assertValid(schema, model);
   });
 
-  it("Should fail when Bool doesn't match exactly ", () => {
+  it("Should fail when Bool doesn't match exactly", () => {
 
     const model: Model = {
       BooleanProp: false

--- a/tests/combinators.spec.ts
+++ b/tests/combinators.spec.ts
@@ -1,16 +1,9 @@
 import { describe, it } from "mocha";
 
 import { Schema, StringSchema, NumberSchema, BooleanSchema } from "../src";
-import { Model } from "./models";
+import { Model, DictionaryPropModel } from "./models";
 import { assertValid, assertInvalid } from "./assertion";
 import { AnyOf, OneOf, AllOf, Not } from "../src/combinators";
-
-export interface RedeemRequest {
-  card: {
-    pan: number
-  };
-  type: string;
-}
 
 /**
  * @see https://json-schema.org/understanding-json-schema/reference/combining.html
@@ -64,6 +57,46 @@ describe("Combinators", () => {
         .build();
 
       assertInvalid(schema, invalidModel);
+    });
+
+    it("Should pass when matching any of for nested objects", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 100
+          }
+        }
+      };
+
+      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new AnyOf([nestedSchema1, nestedSchema2]))
+        .build();
+
+
+      assertValid(schema, model);
+    });
+
+    it("Should fail when not matching any of for nested objects", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 100
+          }
+        }
+      };
+
+      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 150);
+      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new AnyOf([nestedSchema1, nestedSchema2]))
+        .build();
+
+
+      assertInvalid(schema, model);
     });
   });
 
@@ -132,6 +165,67 @@ describe("Combinators", () => {
 
       assertInvalid(schema, invalidModel);
     });
+
+    it("Should pass when matching strictly one of for nested objects", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 100
+          }
+        }
+      };
+
+      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new OneOf([nestedSchema1, nestedSchema2]))
+        .build();
+
+
+      assertValid(schema, model);
+    });
+
+    it("Should fail when matching more than one of for nested objects", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 100
+          }
+        }
+      };
+
+      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new OneOf([nestedSchema1, nestedSchema2]))
+        .build();
+
+
+      assertInvalid(schema, model);
+    });
+
+    it("Should fail when matching none of for nested objects", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 100
+          }
+        }
+      };
+
+      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 150);
+      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new OneOf([nestedSchema1, nestedSchema2]))
+        .build();
+
+
+      assertInvalid(schema, model);
+    });
+
   });
 
   /**
@@ -180,6 +274,46 @@ describe("Combinators", () => {
       assertInvalid(schema, invalidModel1);
       assertInvalid(schema, invalidModel2);
     });
+
+    it("Should pass when matching all of nested objects", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 100
+          }
+        }
+      };
+
+      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new AllOf([nestedSchema1, nestedSchema2]))
+        .build();
+
+
+      assertValid(schema, model);
+    });
+
+    it("Should fail when not matching all of nested objects", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 100
+          }
+        }
+      };
+
+      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new AllOf([nestedSchema1, nestedSchema2]))
+        .build();
+
+
+      assertInvalid(schema, model);
+    });
   });
 
 
@@ -214,6 +348,42 @@ describe("Combinators", () => {
         .build();
 
       assertInvalid(schema, invalidModel);
+    });
+
+    it("Should pass when not matching nested object", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 100
+          }
+        }
+      };
+
+      const nestedSchema = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new Not(nestedSchema))
+        .build();
+
+      assertValid(schema, model);
+    });
+
+    it("Should fail when matching nested object", () => {
+      const model: Model = {
+        DictionaryProp: {
+          "KeyA": {
+            DictionaryChildNumberProp: 49
+          }
+        }
+      };
+
+      const nestedSchema = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+
+      const schema = new Schema<Model>()
+        .with(m => m.DictionaryProp, new Not(nestedSchema))
+        .build();
+
+      assertInvalid(schema, model);
     });
   });
 });

--- a/tests/models.ts
+++ b/tests/models.ts
@@ -4,6 +4,16 @@ export class Model {
   public BooleanProp?: boolean;
   public ArrayProp?: Array<number | string | boolean | any[]>;
   public ObjProp?: Model2;
+  public DictionaryProp?: {
+    [key: string]: DictionaryPropModel
+  };
+}
+
+export class DictionaryPropModel {
+  DictionaryChildStringProp?: string;
+  DictionaryChildNumberProp?: number;
+  DictionaryChildArrayProp?: number[];
+  DictionaryChildBoolProp?: boolean;
 }
 
 export class Model2 {

--- a/tests/models.ts
+++ b/tests/models.ts
@@ -7,6 +7,13 @@ export class Model {
   public DictionaryProp?: {
     [key: string]: DictionaryPropModel
   };
+  public NestedDictionaryProp?: {
+    [key: string]: NestedDictionaryPropModel
+  };
+}
+
+export class NestedDictionaryPropModel {
+  [key: string]: DictionaryPropModel
 }
 
 export class DictionaryPropModel {

--- a/tests/number.spec.ts
+++ b/tests/number.spec.ts
@@ -13,7 +13,7 @@ describe("Number", () => {
    */
   describe("Type", () => {
 
-    it("Should pass when property type matches ", () => {
+    it("Should pass when property type matches", () => {
 
       const model: Model = {
         NumberProp: 123
@@ -66,7 +66,7 @@ describe("Number", () => {
 
   describe("Exact number validation", () => {
 
-    it("Should pass when number matches exactly ", () => {
+    it("Should pass when number matches exactly", () => {
 
       const model: Model = {
         NumberProp: 10

--- a/tests/object.spec.ts
+++ b/tests/object.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "mocha";
 
 import { Schema, ArraySchema, StringSchema, AnyOf, NumberSchema, AllOf, BooleanSchema, OneOf } from "../src";
-import { Model, DictionaryPropModel } from "./models";
+import { Model, DictionaryPropModel, NestedDictionaryPropModel } from "./models";
 import { assertValid, assertInvalid } from "./assertion";
 
 describe("Dictionary", () => {
@@ -153,4 +153,55 @@ describe("Dictionary", () => {
 
   });
 
+
+  it("Should pass when double nested dictionary object is valid", () => {
+
+    const model: Model = {
+      NestedDictionaryProp: {
+        "KeyA": {
+          "KeyA1": {
+            DictionaryChildNumberProp: 50
+          }
+        }
+      }
+    };
+
+
+    const schema = new Schema<Model>()
+      .with(x => x.NestedDictionaryProp,
+        new Schema<NestedDictionaryPropModel>().with(x => x,
+          new Schema<DictionaryPropModel>()
+            .with(x => x.DictionaryChildNumberProp, x => x < 100)
+        )).build();
+
+
+    assertValid(schema, model);
+
+  });
+
+
+  it("Should fail when double nested dictionary object is invalid", () => {
+
+    const model: Model = {
+      NestedDictionaryProp: {
+        "KeyA": {
+          "KeyA1": {
+            DictionaryChildNumberProp: 500
+          }
+        }
+      }
+    };
+
+
+    const schema = new Schema<Model>()
+      .with(x => x.NestedDictionaryProp,
+        new Schema<NestedDictionaryPropModel>().with(x => x,
+          new Schema<DictionaryPropModel>()
+            .with(x => x.DictionaryChildNumberProp, x => x < 100)
+        )).build();
+
+
+    assertInvalid(schema, model);
+
+  });
 });

--- a/tests/object.spec.ts
+++ b/tests/object.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it } from "mocha";
+
+import { Schema, ArraySchema, StringSchema, AnyOf, NumberSchema, AllOf, BooleanSchema, OneOf } from "../src";
+import { Model, DictionaryPropModel } from "./models";
+import { assertValid, assertInvalid } from "./assertion";
+
+describe("Dictionary", () => {
+
+  it("Should pass when nested object property satisfies schema ", () => {
+
+    const model: Model = {
+      DictionaryProp: {
+        "Key1": {
+          DictionaryChildStringProp: "aaa.bbb",
+          DictionaryChildNumberProp: 9,
+          DictionaryChildArrayProp: [1, 2, 3]
+        },
+        "Key2": {
+          DictionaryChildStringProp: "abc",
+          DictionaryChildNumberProp: 49,
+          DictionaryChildArrayProp: [1, 2, 3]
+        }
+      }
+    };
+
+    const schema = new Schema<Model>()
+      .with(m => m.DictionaryProp,
+        new Schema<DictionaryPropModel>()
+          .with(x => x.DictionaryChildNumberProp, x => x < 50)
+          .with(x => x.DictionaryChildStringProp, new AnyOf([
+            /^[A-z]+\.[A-z]+$/, new StringSchema({ enum: ["abc"] })
+          ]))
+          .with(x => x.DictionaryChildArrayProp, new ArraySchema({
+            length: x => x < 5,
+            uniqueItems: true
+          }))
+      )
+      .build();
+
+    assertValid(schema, model);
+
+  });
+
+  it("Should fail when nested object property violates string schema ", () => {
+
+    const model: Model = {
+      DictionaryProp: {
+        "Key1": {
+          DictionaryChildStringProp: "aaa",
+        }
+      }
+    };
+
+    const schema = new Schema<Model>()
+      .with(m => m.DictionaryProp,
+        new Schema<DictionaryPropModel>()
+          .with(x => x.DictionaryChildStringProp, /^[A-z]+\.[A-z]+$/)
+      )
+      .build();
+
+    assertInvalid(schema, model);
+
+  });
+
+  it("Should fail when nested object property violates number schema ", () => {
+
+    const model: Model = {
+      DictionaryProp: {
+        "Key1": {
+          DictionaryChildNumberProp: 50
+        }
+      }
+    };
+
+    const schema = new Schema<Model>()
+      .with(m => m.DictionaryProp,
+        new Schema<DictionaryPropModel>()
+          .with(x => x.DictionaryChildNumberProp, x => x < 50)
+      )
+      .build();
+
+    assertInvalid(schema, model);
+
+  });
+
+  it("Should fail when nested object property violates array schema ", () => {
+
+    const model: Model = {
+      DictionaryProp: {
+        "Key1": {
+          DictionaryChildArrayProp: [1, 2, 3, 3]
+        }
+      }
+    };
+
+    const schema = new Schema<Model>()
+      .with(m => m.DictionaryProp,
+        new Schema<DictionaryPropModel>()
+          .with(x => x.DictionaryChildArrayProp, new ArraySchema({
+            length: x => x < 5,
+            uniqueItems: true
+          }))
+      )
+      .build();
+
+    assertInvalid(schema, model);
+
+  });
+
+  it("Should fail when nested object property violates boolean schema ", () => {
+
+    const model: Model = {
+      DictionaryProp: {
+        "Key1": {
+          DictionaryChildBoolProp: null
+        }
+      }
+    };
+
+    const schema = new Schema<Model>()
+      .with(m => m.DictionaryProp,
+        new Schema<DictionaryPropModel>()
+          .with(x => x.DictionaryChildBoolProp, new BooleanSchema({
+            required: true
+          }))
+      )
+      .build();
+
+    assertInvalid(schema, model);
+
+  });
+
+  it("Should fail when nested object property violates combinator schema ", () => {
+
+    const model: Model = {
+      DictionaryProp: {
+        "Key1": {
+          DictionaryChildStringProp: "abc.def"
+        }
+      }
+    };
+
+    const schema = new Schema<Model>()
+      .with(m => m.DictionaryProp,
+        new Schema<DictionaryPropModel>()
+          .with(x => x.DictionaryChildStringProp, new OneOf([
+            /^[A-z]+\.[A-z]+$/, new StringSchema({ length: x => x === 7 })
+          ]))
+      )
+      .build();
+
+    assertInvalid(schema, model);
+
+  });
+
+});

--- a/tests/object.spec.ts
+++ b/tests/object.spec.ts
@@ -6,7 +6,7 @@ import { assertValid, assertInvalid } from "./assertion";
 
 describe("Dictionary", () => {
 
-  it("Should pass when nested object property satisfies schema ", () => {
+  it("Should pass when nested object property satisfies schema", () => {
 
     const model: Model = {
       DictionaryProp: {
@@ -41,7 +41,7 @@ describe("Dictionary", () => {
 
   });
 
-  it("Should fail when nested object property violates string schema ", () => {
+  it("Should fail when nested object property violates string schema", () => {
 
     const model: Model = {
       DictionaryProp: {
@@ -62,7 +62,7 @@ describe("Dictionary", () => {
 
   });
 
-  it("Should fail when nested object property violates number schema ", () => {
+  it("Should fail when nested object property violates number schema", () => {
 
     const model: Model = {
       DictionaryProp: {
@@ -83,7 +83,7 @@ describe("Dictionary", () => {
 
   });
 
-  it("Should fail when nested object property violates array schema ", () => {
+  it("Should fail when nested object property violates array schema", () => {
 
     const model: Model = {
       DictionaryProp: {
@@ -107,7 +107,7 @@ describe("Dictionary", () => {
 
   });
 
-  it("Should fail when nested object property violates boolean schema ", () => {
+  it("Should fail when nested object property violates boolean schema", () => {
 
     const model: Model = {
       DictionaryProp: {
@@ -120,9 +120,7 @@ describe("Dictionary", () => {
     const schema = new Schema<Model>()
       .with(m => m.DictionaryProp,
         new Schema<DictionaryPropModel>()
-          .with(x => x.DictionaryChildBoolProp, new BooleanSchema({
-            required: true
-          }))
+          .with(x => x.DictionaryChildBoolProp, new BooleanSchema())
       )
       .build();
 
@@ -130,7 +128,7 @@ describe("Dictionary", () => {
 
   });
 
-  it("Should fail when nested object property violates combinator schema ", () => {
+  it("Should fail when nested object property violates combinator schema", () => {
 
     const model: Model = {
       DictionaryProp: {

--- a/tests/schema.spec.ts
+++ b/tests/schema.spec.ts
@@ -4,13 +4,6 @@ import { Schema, ArraySchema, StringSchema, AnyOf, NumberSchema, AllOf } from ".
 import { Model } from "./models";
 import { assertValid, assertInvalid } from "./assertion";
 
-export interface RedeemRequest {
-  card: {
-    pan: number
-  };
-  type: string;
-}
-
 describe("Usage", () => {
 
   it("Complete picture", () => {

--- a/tests/string.spec.ts
+++ b/tests/string.spec.ts
@@ -11,7 +11,7 @@ describe("String", () => {
    */
   describe("Type", () => {
 
-    it("Should pass when string property type matches ", () => {
+    it("Should pass when string property type matches", () => {
 
       const model: Model = {
         StringProp: "abc.def"
@@ -65,7 +65,7 @@ describe("String", () => {
 
   describe("Exact string validation", () => {
 
-    it("Should pass when string matches exactly ", () => {
+    it("Should pass when string matches exactly", () => {
 
       const model: Model = {
         StringProp: "abc.def"


### PR DESCRIPTION
Adds support for nested objects, this allows to create a schema for arbitrary dictionary objects where the nested structure is defined but keys are not. e.g OpenAPI spec

```js

  "paths": {
    "/my-resource": {
      "post": {
        "tags": [
          "resource"
        ],
        "summary": "Create my Resource"

```
In the above example, resource structure is well defined, but the path identifiers are not.

The second commit in this PR adds support for double nested dictionaries. e.g:
```js
{
      NestedDictionaryProp: {
        "KeyA": {
          "KeyA1": {
            DictionaryChildNumberProp: 500
          }
        }
      }
    }
```

## Type of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](/justeat/ts-jsonschema-builder/pullspulls) for the same update/change?
* [x] I have updated the documentation accordingly.

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?