### PR TITLE
Add array of objects support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/ts-jsonschema-builder",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Fluent TypeScript JSON Schema Builder with IntelliSense support.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/array-schema.ts
+++ b/src/array-schema.ts
@@ -45,7 +45,7 @@ export interface IArraySchema extends ITypeSchema<"array"> {
    *    })
    * })
    */
-  items?: any[] | TypeSchema<string | number | boolean>;
+  items?: Array<any> | TypeSchema<string | number | boolean>;
 
   /**
    * @description The additionalItems keyword controls whether it’s valid to have additional items in the array beyond what is defined in items.
@@ -60,7 +60,7 @@ export class ArraySchema extends TypeSchema<"array"> {
   public readonly minItems?: number;
   public readonly maxItems?: number;
   public readonly uniqueItems?: boolean;
-  public readonly items?: any[] | PropertySchema;
+  public readonly items?: Array<any> | PropertySchema;
   public readonly additionalItems?: boolean;
 
   constructor(schema: IArraySchema = {}) {

--- a/src/array-schema.ts
+++ b/src/array-schema.ts
@@ -1,5 +1,6 @@
 import { ITypeSchema, TypeSchema, PropertySchema } from "./type-schema";
 import { parseAsRange } from "./expression-parser";
+import { Schema } from "./schema";
 
 
 export interface IArraySchema extends ITypeSchema<"array"> {
@@ -83,6 +84,7 @@ export class ArraySchema extends TypeSchema<"array"> {
         enum: [i]
       };
     });
-    if (schema.items && schema.items instanceof PropertySchema) this.items = schema.items.compile();
+    if (schema.items && schema.items instanceof Schema) this.items = schema.items.compile().additionalProperties as PropertySchema;
+    else if (schema.items && schema.items instanceof PropertySchema) this.items = schema.items.compile();
   }
 }

--- a/src/boolean-schema.ts
+++ b/src/boolean-schema.ts
@@ -7,13 +7,13 @@ export interface IBooleanSchema extends ITypeSchema<"boolean"> {
    * @description The enum keyword is used to restrict a value to a fixed set of values. It must be an array with at least one element, where each element is unique.
    * @see https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values
    */
-  enum?: boolean[];
+  enum?: Array<boolean>;
 }
 
 export class BooleanSchema extends TypeSchema<"boolean"> {
   public readonly type = "boolean";
 
-  public enum?: boolean[];
+  public enum?: Array<boolean>;
 
   constructor();
   constructor(schema: boolean);

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -8,9 +8,9 @@ export type Combination = string | RegExp | number | boolean | PropertySchema;
  * @see https://json-schema.org/understanding-json-schema/reference/combining.html#anyof
  */
 export class AnyOf extends PropertySchema {
-  public anyOf: PropertySchema[];
+  public anyOf: Array<PropertySchema>;
 
-  constructor(schemas: Combination[]) {
+  constructor(schemas: Array<Combination>) {
     super({ required: true });
     this.anyOf = schemas.map(s => parseSchema(s).compile());
   }
@@ -21,10 +21,10 @@ export class AnyOf extends PropertySchema {
  * @see https://json-schema.org/understanding-json-schema/reference/combining.html#oneof
  */
 export class OneOf extends PropertySchema {
-  public oneOf: PropertySchema[];
+  public oneOf: Array<PropertySchema>;
   public required: boolean = true;
 
-  constructor(schemas: Combination[]) {
+  constructor(schemas: Array<Combination>) {
     super({ required: true });
     this.oneOf = schemas.map(s => parseSchema(s).compile());
   }
@@ -35,10 +35,10 @@ export class OneOf extends PropertySchema {
  * @see https://json-schema.org/understanding-json-schema/reference/combining.html#allof
  */
 export class AllOf extends PropertySchema {
-  public allOf: PropertySchema[];
+  public allOf: Array<PropertySchema>;
   public required: boolean = true;
 
-  constructor(schemas: Combination[]) {
+  constructor(schemas: Array<Combination>) {
     super({ required: true });
     this.allOf = schemas.map(s => parseSchema(s).compile());
   }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -124,12 +124,12 @@ export class Schema<T> extends TypeSchema<"object"> {
 
   /**
    * @description Specify schema for a array property
-   * @param {(model: T) => any[]} selector Array property selector
+   * @param {(model: T) => Array<any>} selector Array property selector
    * @param {IArraySchema} schema Array schema
    * @example
    * .with(m => m.ArrayProp, new ArraySchema({...}));
    */
-  with(selector: (model: T) => any[] | undefined, schema: IArraySchema): Schema<T>;
+  with(selector: (model: T) => Array<any> | undefined, schema: IArraySchema): Schema<T>;
   with(selector: any, schema: any): any {
     const expression = this.getExpression(selector);
 
@@ -138,7 +138,7 @@ export class Schema<T> extends TypeSchema<"object"> {
     if (expression.type === "Identifier") {
       this.additionalProperties = normalizedSchema.compile();
     } else {
-      const invertedExpression: { title: string, leaf?: boolean }[] = [];
+      const invertedExpression: Array<{ title: string, leaf?: boolean }> = [];
       let nextObj: MemberExpression | null = expression;
       while (nextObj) {
         invertedExpression.unshift({

--- a/src/string-schema.ts
+++ b/src/string-schema.ts
@@ -43,7 +43,7 @@ export interface IStringSchema extends ITypeSchema<"string"> {
    * @description The enum keyword is used to restrict a value to a fixed set of values. It must be an array with at least one element, where each element is unique.
    * @see https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values
    */
-  enum?: string[];
+  enum?: Array<string>;
 }
 
 export class StringSchema extends TypeSchema<"string">  {
@@ -53,7 +53,7 @@ export class StringSchema extends TypeSchema<"string">  {
   public readonly pattern?: string;
   public readonly minLength?: number;
   public readonly maxLength?: number;
-  enum?: string[];
+  enum?: Array<string>;
 
   constructor();
   constructor(schema: (model: number) => boolean);

--- a/tests/array.spec.ts
+++ b/tests/array.spec.ts
@@ -1,6 +1,6 @@
 
 import { testCase } from "./test-case";
-import { Model } from "./models";
+import { Model, Model2 } from "./models";
 import { Schema, ArraySchema, NumberSchema, StringSchema, BooleanSchema, AnyOf } from "../src";
 import { assertValid, assertInvalid, assert } from "./assertion";
 
@@ -302,6 +302,64 @@ describe("Array", () => {
       const schema = new Schema<Model>()
         .with(m => m.ArrayProp, new ArraySchema({
           items: new BooleanSchema()
+        }))
+        .build();
+
+      assertInvalid(schema, model);
+    });
+  });
+
+  describe("Array of objects", () => {
+    it("Should pass when all items are matching specified object schema", () => {
+
+      const model: Model = {
+        ObjArrayProp: [
+          {
+            Lvl2ObjProp: {
+              Lvl3StrProp: "abc"
+            }
+          },
+          {
+            Lvl2ObjProp: {
+              Lvl3StrProp: "def"
+            }
+          }
+        ]
+      };
+
+      const schema = new Schema<Model>()
+        .with(x => x.ObjArrayProp, new ArraySchema({
+          items: new Schema<Model2>().with(x => x.Lvl2ObjProp.Lvl3StrProp, new StringSchema({
+            minLength: 1
+          }))
+        }))
+        .build();
+
+      assertValid(schema, model);
+    });
+
+    it("Should fail when one of items is not matching specified object schema", () => {
+
+      const model: Model = {
+        ObjArrayProp: [
+          {
+            Lvl2ObjProp: {
+              Lvl3StrProp: "abcdef"
+            }
+          },
+          {
+            Lvl2ObjProp: {
+              Lvl3StrProp: "xyz"
+            }
+          }
+        ]
+      };
+
+      const schema = new Schema<Model>()
+        .with(x => x.ObjArrayProp, new ArraySchema({
+          items: new Schema<Model2>().with(x => x.Lvl2ObjProp.Lvl3StrProp, new StringSchema({
+            minLength: 5
+          }))
         }))
         .build();
 

--- a/tests/assertion.ts
+++ b/tests/assertion.ts
@@ -10,11 +10,11 @@ export function assertValid(schema: Object, model: any): void {
   assert(true, schema, model);
 }
 
-export function assertInvalid(schema: Object, model: any): Ajv.ErrorObject[] {
+export function assertInvalid(schema: Object, model: any): Array<Ajv.ErrorObject> {
   return assert(false, schema, model);
 }
 
-export function assert(expected: boolean, schema: Object, model: any): Ajv.ErrorObject[] {
+export function assert(expected: boolean, schema: Object, model: any): Array<Ajv.ErrorObject> {
 
 
   const validator = ajv.compile(schema);

--- a/tests/assertion.ts
+++ b/tests/assertion.ts
@@ -3,19 +3,22 @@ import { should } from "chai";
 
 should();
 
-const ajv = new Ajv({ schemaId: "id" });
+const ajv = new Ajv({ schemaId: "id", allErrors: true });
 ajv.addMetaSchema(require("ajv/lib/refs/json-schema-draft-04.json"));
 
-export function assertValid(schema: Object, model: any) {
+export function assertValid(schema: Object, model: any): void {
   assert(true, schema, model);
 }
 
-export function assertInvalid(schema: Object, model: any) {
-  assert(false, schema, model);
+export function assertInvalid(schema: Object, model: any): Ajv.ErrorObject[] {
+  return assert(false, schema, model);
 }
 
-export function assert(expected: boolean, schema: Object, model: any) {
+export function assert(expected: boolean, schema: Object, model: any): Ajv.ErrorObject[] {
+
+
   const validator = ajv.compile(schema);
   const isValid = validator(model);
   isValid.should.be.eql(expected, JSON.stringify(validator.errors));
+  return validator.errors;
 }

--- a/tests/models.ts
+++ b/tests/models.ts
@@ -4,6 +4,7 @@ export class Model {
   public BooleanProp?: boolean;
   public ArrayProp?: Array<number | string | boolean | any[]>;
   public ObjProp?: Model2;
+  public ObjArrayProp?: Array<Model2>;
   public DictionaryProp?: {
     [key: string]: DictionaryPropModel
   };

--- a/tests/models.ts
+++ b/tests/models.ts
@@ -2,7 +2,7 @@ export class Model {
   public StringProp?: string;
   public NumberProp?: number;
   public BooleanProp?: boolean;
-  public ArrayProp?: Array<number | string | boolean | any[]>;
+  public ArrayProp?: Array<number | string | boolean | Array<any>>;
   public ObjProp?: Model2;
   public ObjArrayProp?: Array<Model2>;
   public DictionaryProp?: {
@@ -20,8 +20,9 @@ export class NestedDictionaryPropModel {
 export class DictionaryPropModel {
   DictionaryChildStringProp?: string;
   DictionaryChildNumberProp?: number;
-  DictionaryChildArrayProp?: number[];
+  DictionaryChildArrayProp?: Array<number>;
   DictionaryChildBoolProp?: boolean;
+  DictionaryChildObjectArrayProp?: Array<Model3>;
 }
 
 export class Model2 {

--- a/tests/object.spec.ts
+++ b/tests/object.spec.ts
@@ -3,6 +3,7 @@ import { describe, it } from "mocha";
 import { Schema, ArraySchema, StringSchema, AnyOf, NumberSchema, AllOf, BooleanSchema, OneOf } from "../src";
 import { Model, DictionaryPropModel, NestedDictionaryPropModel } from "./models";
 import { assertValid, assertInvalid } from "./assertion";
+import { expect } from "chai";
 
 describe("Dictionary", () => {
 
@@ -47,6 +48,7 @@ describe("Dictionary", () => {
       DictionaryProp: {
         "Key1": {
           DictionaryChildStringProp: "aaa",
+          DictionaryChildNumberProp: 50
         }
       }
     };
@@ -55,11 +57,30 @@ describe("Dictionary", () => {
       .with(m => m.DictionaryProp,
         new Schema<DictionaryPropModel>()
           .with(x => x.DictionaryChildStringProp, /^[A-z]+\.[A-z]+$/)
+          .with(x => x.DictionaryChildNumberProp, x => x > 100)
       )
       .build();
 
-    assertInvalid(schema, model);
+    const errors = assertInvalid(schema, model);
+    expect(errors.length).to.be.eq(2);
 
+  });
+
+  it("Should fail with multiple errors", () => {
+
+    const model: Model = {
+      NumberProp: 50,
+      StringProp: "aaa"
+    };
+
+    const schema = new Schema<Model>()
+      .with(x => x.StringProp, /^[A-z]+\.[A-z]+$/)
+      .with(x => x.NumberProp, x => x > 100)
+      .build();
+
+    const errors = assertInvalid(schema, model);
+
+    expect(errors.length).to.be.eq(2);
   });
 
   it("Should fail when nested object property violates number schema", () => {

--- a/tests/object.spec.ts
+++ b/tests/object.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "mocha";
 
 import { Schema, ArraySchema, StringSchema, AnyOf, NumberSchema, AllOf, BooleanSchema, OneOf } from "../src";
-import { Model, DictionaryPropModel, NestedDictionaryPropModel } from "./models";
+import { Model, DictionaryPropModel, NestedDictionaryPropModel, Model3 } from "./models";
 import { assertValid, assertInvalid } from "./assertion";
 import { expect } from "chai";
 
@@ -14,12 +14,18 @@ describe("Dictionary", () => {
         "Key1": {
           DictionaryChildStringProp: "aaa.bbb",
           DictionaryChildNumberProp: 9,
-          DictionaryChildArrayProp: [1, 2, 3]
+          DictionaryChildArrayProp: [1, 2, 3],
+          DictionaryChildObjectArrayProp: [{
+            Lvl3StrProp: "aaaaa"
+          }]
         },
         "Key2": {
           DictionaryChildStringProp: "abc",
           DictionaryChildNumberProp: 49,
-          DictionaryChildArrayProp: [1, 2, 3]
+          DictionaryChildArrayProp: [1, 2, 3],
+          DictionaryChildObjectArrayProp: [{
+            Lvl3StrProp: "bbbbb"
+          }]
         }
       }
     };
@@ -35,6 +41,16 @@ describe("Dictionary", () => {
             length: x => x < 5,
             uniqueItems: true
           }))
+          .with(x => x.DictionaryChildObjectArrayProp, new ArraySchema({
+            length: x => x >= 1,
+            uniqueItems: true,
+            items: new Schema<Model3>().with(
+              x => x.Lvl3StrProp,
+              new StringSchema({
+                minLength: 5
+              })
+            )
+          }))
       )
       .build();
 
@@ -48,7 +64,12 @@ describe("Dictionary", () => {
       DictionaryProp: {
         "Key1": {
           DictionaryChildStringProp: "aaa",
-          DictionaryChildNumberProp: 50
+          DictionaryChildNumberProp: 50,
+          DictionaryChildObjectArrayProp: [{
+            Lvl3StrProp: "aaaaa"
+          }, {
+            Lvl3StrProp: "aaaaa"
+          }]
         }
       }
     };
@@ -58,11 +79,33 @@ describe("Dictionary", () => {
         new Schema<DictionaryPropModel>()
           .with(x => x.DictionaryChildStringProp, /^[A-z]+\.[A-z]+$/)
           .with(x => x.DictionaryChildNumberProp, x => x > 100)
+          .with(x => x.DictionaryChildObjectArrayProp, new ArraySchema({
+            length: x => x >= 1,
+            uniqueItems: true,
+            items: new Schema<Model3>().with(
+              x => x.Lvl3StrProp,
+              new StringSchema({
+                minLength: 5
+              })
+            )
+          }))
       )
       .build();
 
     const errors = assertInvalid(schema, model);
-    expect(errors.length).to.be.eq(2);
+    expect(errors.length).to.be.eq(3);
+
+    const patternError = errors.find(err => err.keyword === "pattern");
+    expect(patternError).to.not.be.null;
+    expect(patternError.dataPath).to.be.eq(".DictionaryProp['Key1'].DictionaryChildStringProp");
+
+    const exclusiveMinimumError = errors.find(err => err.keyword === "exclusiveMinimum");
+    expect(exclusiveMinimumError).to.not.be.null;
+    expect(exclusiveMinimumError.dataPath).to.be.eq(".DictionaryProp['Key1'].DictionaryChildNumberProp");
+
+    const uniqueItemsError = errors.find(err => err.keyword === "uniqueItems");
+    expect(uniqueItemsError).to.not.be.null;
+    expect(uniqueItemsError.dataPath).to.be.eq(".DictionaryProp['Key1'].DictionaryChildObjectArrayProp");
 
   });
 
@@ -81,6 +124,15 @@ describe("Dictionary", () => {
     const errors = assertInvalid(schema, model);
 
     expect(errors.length).to.be.eq(2);
+
+    const patternError = errors.find(err => err.keyword === "pattern");
+    expect(patternError).to.not.be.null;
+    expect(patternError.dataPath).to.be.eq(".StringProp");
+
+    const exclusiveMinimumError = errors.find(err => err.keyword === "exclusiveMinimum");
+    expect(exclusiveMinimumError).to.not.be.null;
+    expect(exclusiveMinimumError.dataPath).to.be.eq(".NumberProp");
+
   });
 
   it("Should fail when nested object property violates number schema", () => {

--- a/tests/test-case.ts
+++ b/tests/test-case.ts
@@ -3,7 +3,7 @@ export interface ITestCase {
   [x: string]: any;
 }
 
-export function testCase<T extends ITestCase>(cases: T[], callback: (c: T) => void) {
+export function testCase<T extends ITestCase>(cases: Array<T>, callback: (c: T) => void) {
   cases.forEach((c, i) => {
     c.reason = `case #(${i + 1})${c.reason ? ` - ${c.reason}` : ""}`;
     callback(c);

--- a/tslint.json
+++ b/tslint.json
@@ -63,7 +63,7 @@
     "no-return-await": true,
     "no-trailing-whitespace": true,
     "no-unsafe-finally": true,
-    "no-unused-expression": true,
+    "no-unused-expression": false,
     "no-var-keyword": true,
     "one-line": [
       true,


### PR DESCRIPTION
An array of complex objects was not producing correct schema.
Sample usage:
```typescript

      const schema = new Schema<Model>()
        .with(x => x.ObjArrayProp, new ArraySchema({
          items: new Schema<Model2>().with(x => x.Lvl2ObjProp.Lvl3StrProp, new StringSchema({
            minLength: 1
          }))
        }))
        .build();
```

## Type of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](/justeat/ts-jsonschema-builder/pullspulls) for the same update/change?
* [x] I have updated the documentation accordingly.

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
