### PR TITLE
#11 - Fixes using strings as names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [{
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}\\dist\\index.js",
+      "preLaunchTask": "tsc: build - tsconfig.json",
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ]
+    },
+    {
+      "name": "MochaTests",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "protocol": "inspector",
+      "timeout": 5000,
+      "stopOnEntry": false
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
     "combinators",
     "estree",
     "spec"
-  ]
+  ],
+  "mochaExplorer.files": "tests/**/*.ts",
+  "mochaExplorer.require": "ts-node/register",
+  "mochaExplorer.debuggerConfig": "MochaTests"
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,5 @@
 import * as esprima from "esprima";
-import { MemberExpression, Identifier, ArrowFunctionExpression, ExpressionStatement, ReturnStatement, Literal } from 'estree';
+import { MemberExpression, Identifier, ArrowFunctionExpression, ExpressionStatement, ReturnStatement, Literal } from "estree";
 
 import { StringSchema, INumberSchema, IBooleanSchema, IArraySchema } from "./";
 import { parseSchema } from "./schema-parser";

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,5 @@
 import * as esprima from "esprima";
-import { MemberExpression, Identifier, ArrowFunctionExpression, ExpressionStatement, ReturnStatement } from "estree";
+import { MemberExpression, Identifier, ArrowFunctionExpression, ExpressionStatement, ReturnStatement, Literal } from 'estree';
 
 import { StringSchema, INumberSchema, IBooleanSchema, IArraySchema } from "./";
 import { parseSchema } from "./schema-parser";
@@ -141,9 +141,16 @@ export class Schema<T> extends TypeSchema<"object"> {
       const invertedExpression: Array<{ title: string, leaf?: boolean }> = [];
       let nextObj: MemberExpression | null = expression;
       while (nextObj) {
-        invertedExpression.unshift({
-          title: (nextObj.property as Identifier).name
-        });
+        if (nextObj.property.type === "Identifier") {
+          invertedExpression.unshift({
+            title: (nextObj.property as Identifier).name
+          });
+        } else {
+          invertedExpression.unshift({
+            title: (nextObj.property as Literal).value.toString()
+          });
+        }
+
         nextObj = nextObj.object.type === "MemberExpression" ? nextObj.object as MemberExpression : null;
       }
       invertedExpression[invertedExpression.length - 1].leaf = true;

--- a/tests/models.ts
+++ b/tests/models.ts
@@ -1,4 +1,5 @@
 export class Model {
+  public "Quote-Prop"?: string;
   public StringProp?: string;
   public NumberProp?: number;
   public BooleanProp?: boolean;

--- a/tests/string.spec.ts
+++ b/tests/string.spec.ts
@@ -24,6 +24,18 @@ describe("String", () => {
       assertValid(schema, model);
     });
 
+    it("Should pass when string property name is a string", () => {
+
+      const model: Model = {};
+      model["Quote Prop"] = "abc.def";
+
+      const schema = new Schema<Model>()
+        .with(m => m["Quote Prop"], new StringSchema())
+        .build();
+
+      assertValid(schema, model);
+    });
+
     it("Should fail when type doesn't match", () => {
 
       const model = {

--- a/tests/string.spec.ts
+++ b/tests/string.spec.ts
@@ -36,6 +36,21 @@ describe("String", () => {
       assertValid(schema, model);
     });
 
+    it("Should pass when string property names are mixed with non-string property names", () => {
+
+      const model: Model = {
+        StringProp: "test.me"
+      };
+      model["Quote Prop"] = "abc.def";
+
+      const schema = new Schema<Model>()
+        .with(m => m["Quote Prop"], new StringSchema())
+        .with(m => m.StringProp, new StringSchema())
+        .build();
+
+      assertValid(schema, model);
+    });
+
     it("Should fail when type doesn't match", () => {
 
       const model = {


### PR DESCRIPTION
# Description

Fixes https://github.com/justeat/ts-jsonschema-builder/issues/11. Extracts the property name correctly if the property name is parsed as a Literal.

## Type of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](/justeat/ts-jsonschema-builder/pullspulls) for the same update/change?
* [ ] I have updated the documentation accordingly.

### New Feature Submissions:

* [x] Does your submission pass tests?
* [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?