### PR TITLE
Nested Objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "12"
 
 cache: npm
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "@justeat/ts-jsonschema-builder",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -25,9 +25,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
-      "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.8.tgz",
+      "integrity": "sha512-U1bQiWbln41Yo6EeHMr+34aUhvrMVyrhn9lYfPSpLTCrZlGxU4Rtn1bocX+0p2Fc/Jkd2FanCEXdw0WNfHHM0w==",
       "dev": true
     },
     "@types/esprima": {
@@ -59,18 +59,18 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.20.tgz",
-      "integrity": "sha512-VAe+DiwpnC/g448uN+/3gRl4th0BTdrR9gSLIOHA+SUQskaYZQDOHG7xmjiE7JUhjbXnbXytf6Ih+/pA6CtMFQ==",
+      "version": "12.12.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+      "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
       "dev": true
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -95,6 +95,16 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -124,6 +134,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -132,6 +148,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "browser-stdout": {
@@ -199,6 +224,22 @@
       "resolved": "http://packages.je-labs.com/npm/private-npm/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -319,22 +360,22 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.17.0-next.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
-      "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -366,16 +407,25 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "http://packages.je-labs.com/npm/private-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "http://packages.je-labs.com/npm/private-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
     },
     "find-up": {
       "version": "3.0.0",
@@ -400,6 +450,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -431,6 +488,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "growl": {
@@ -482,6 +548,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
@@ -489,21 +564,42 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
     "is-regex": {
@@ -627,13 +723,14 @@
       }
     },
     "mocha": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
-      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.1.tgz",
+      "integrity": "sha512-9eWmWTdHLXh72rGrdZjNbG3aa1/3NRPpul1z0D979QpEnFdCG0Q5tv834N+94QEN2cysfV72YocQ3fn87s70fg==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
         "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
@@ -646,7 +743,7 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "ms": "2.1.1",
-        "node-environment-flags": "1.0.5",
+        "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
         "strip-json-comments": "2.0.1",
         "supports-color": "6.0.0",
@@ -664,14 +761,20 @@
       "dev": true
     },
     "node-environment-flags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -717,9 +820,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -764,11 +867,26 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -783,9 +901,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.0.tgz",
-      "integrity": "sha512-uviWSi5N67j3t3UKFxej1loCH0VZn5XuqdNxoLShPcYPw6cUZn74K1VRj+9myynRX03bxIBEkwlkob/ujLsJVw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+      "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -836,9 +954,9 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -846,9 +964,9 @@
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -884,6 +1002,15 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "ts-mocha": {
@@ -950,9 +1077,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.0.0.tgz",
+      "integrity": "sha512-9nLya8GBtlFmmFMW7oXXwoXS1NkrccqTqAtwXzdPV9e2mqSEvCki6iHL/Fbzi5oqbugshzgGPk7KBb2qNP1DSA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -966,14 +1093,14 @@
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.10.0",
         "tsutils": "^2.29.0"
       },
       "dependencies": {
         "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
       }
@@ -994,9 +1121,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/ts-jsonschema-builder",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "Fluent TypeScript JSON Schema Builder with IntelliSense support.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,15 +21,15 @@
     "esprima": "^4.0.1"
   },
   "devDependencies": {
-    "@types/node": "^12.12.20",
-    "typescript": "^3.7.3",
-    "@types/chai": "^4.2.7",
+    "@types/node": "^12.12.26",
+    "typescript": "^3.7.5",
+    "@types/chai": "^4.2.8",
     "@types/esprima": "^4.0.2",
     "@types/mocha": "^5.2.7",
-    "ajv": "^6.10.2",
+    "ajv": "^6.11.0",
     "chai": "^4.2.0",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.1",
     "ts-mocha": "^6.0.0",
-    "tslint": "^5.20.1"
+    "tslint": "^6.0.0"
   }
 }

--- a/src/array-schema.ts
+++ b/src/array-schema.ts
@@ -84,7 +84,7 @@ export class ArraySchema extends TypeSchema<"array"> {
         enum: [i]
       };
     });
-    if (schema.items && schema.items instanceof Schema) this.items = schema.items.compile().additionalProperties as PropertySchema;
+    if (schema.items && schema.items instanceof Schema) this.items = schema.items.compile();
     else if (schema.items && schema.items instanceof PropertySchema) this.items = schema.items.compile();
   }
 }

--- a/src/schema-parser.ts
+++ b/src/schema-parser.ts
@@ -16,6 +16,7 @@ export function parseSchema(value: any): PropertySchema {
   if (typeof value === "object" && value.constructor.name === "AllOf") return value;
   if (typeof value === "object" && value.constructor.name === "Not") return value;
   if (typeof value === "object" && value.constructor.name === "Schema") return value;
+  if (typeof value === "object" && value.constructor.name === "DictionarySchema") return value;
 
   if (value instanceof Function) return new NumberSchema(value);
 

--- a/src/type-schema.ts
+++ b/src/type-schema.ts
@@ -1,23 +1,21 @@
-
 export interface ISchema {
   required?: boolean;
 }
+
 export interface ITypeSchema<T> extends ISchema {
   readonly type?: T;
 }
 
 export class PropertySchema implements ISchema {
-  public isSchema = true;
   public required?: boolean = true;
 
   constructor(schema: ISchema) {
     schema = schema || {};
     this.required = typeof schema.required === "undefined" ? this.required : schema.required;
-    Object.defineProperty(this, "isSchema", { enumerable: false, writable: true });
     Object.defineProperty(this, "required", { enumerable: false, writable: true });
   }
 
-  public compile() {
+  public compile(): any {
     return Object.assign({}, this);
   }
 }

--- a/tests/array.spec.ts
+++ b/tests/array.spec.ts
@@ -359,11 +359,12 @@ describe("Array", () => {
         .with(x => x.ObjArrayProp, new ArraySchema({
           items: new Schema<Model2>().with(x => x.Lvl2ObjProp.Lvl3StrProp, new StringSchema({
             minLength: 5
-          }))
-        }))
-        .build();
+          })),
+          minItems: 1
+        }));
 
-      assertInvalid(schema, model);
+
+      assertInvalid(schema.build(), model);
     });
   });
 });

--- a/tests/combinators.spec.ts
+++ b/tests/combinators.spec.ts
@@ -1,6 +1,4 @@
-import { describe, it } from "mocha";
-
-import { Schema, StringSchema, NumberSchema, BooleanSchema } from "../src";
+import { Schema, StringSchema, NumberSchema, BooleanSchema, DictionarySchema } from "../src";
 import { Model, DictionaryPropModel } from "./models";
 import { assertValid, assertInvalid } from "./assertion";
 import { AnyOf, OneOf, AllOf, Not } from "../src/combinators";
@@ -68,8 +66,8 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
-      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+      const nestedSchema1 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new AnyOf([nestedSchema1, nestedSchema2]))
@@ -88,8 +86,8 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 150);
-      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+      const nestedSchema1 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 150);
+      const nestedSchema2 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new AnyOf([nestedSchema1, nestedSchema2]))
@@ -175,8 +173,8 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
-      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+      const nestedSchema1 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new OneOf([nestedSchema1, nestedSchema2]))
@@ -195,8 +193,8 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
-      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 50);
+      const nestedSchema1 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new OneOf([nestedSchema1, nestedSchema2]))
@@ -215,8 +213,8 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 150);
-      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+      const nestedSchema1 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 150);
+      const nestedSchema2 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new OneOf([nestedSchema1, nestedSchema2]))
@@ -284,8 +282,8 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
-      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 50);
+      const nestedSchema1 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x > 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new AllOf([nestedSchema1, nestedSchema2]))
@@ -304,8 +302,8 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema1 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
-      const nestedSchema2 = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+      const nestedSchema1 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 150);
+      const nestedSchema2 = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new AllOf([nestedSchema1, nestedSchema2]))
@@ -359,7 +357,7 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+      const nestedSchema = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new Not(nestedSchema))
@@ -377,7 +375,7 @@ describe("Combinators", () => {
         }
       };
 
-      const nestedSchema = new Schema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
+      const nestedSchema = new DictionarySchema<DictionaryPropModel>().with(x => x.DictionaryChildNumberProp, x => x < 50);
 
       const schema = new Schema<Model>()
         .with(m => m.DictionaryProp, new Not(nestedSchema))

--- a/tests/schema.spec.ts
+++ b/tests/schema.spec.ts
@@ -1,5 +1,3 @@
-import { describe, it } from "mocha";
-
 import { Schema, ArraySchema, StringSchema, AnyOf, NumberSchema, AllOf } from "../src";
 import { Model } from "./models";
 import { assertValid, assertInvalid } from "./assertion";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     ]
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "tests/**/*.ts"
   ],
   "exclude": [
     "./out",


### PR DESCRIPTION
Add support for nested object Schema for objects that are not Dictionaries.

#8 has introduced nested schemas. But it only accounted for Dictionaries: objects with arbitrary keys. This was a little design mistake since there was no nice way to address nested Objects with defined schema. This PR changes dictionary syntax to use `DictionarySchema<T>` and reserves nested `Schema<T>` for structured objects.

Since the change is breaking - the major version of the package is increased.


## Type of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](/justeat/ts-jsonschema-builder/pullspulls) for the same update/change?
* [ ] I have updated the documentation accordingly.

### New Feature Submissions:

* [x] Does your submission pass tests?
* [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
